### PR TITLE
clean venv based install for developers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,8 @@ build
 *.venv
 .DS_Store
 nanobot
+uv.lock
+web/tsconfig.tsbuildinfo
 
 # PyPI 配置（包含敏感信息）
 .pypirc

--- a/README.md
+++ b/README.md
@@ -228,16 +228,17 @@ Model: gpt-4o
 
 ## Development
 
-**Prerequisites:** Python ≥ 3.11, [Bun](https://bun.sh) ≥ 1.0
+**Prerequisites:** Python ≥ 3.11, [Bun](https://bun.sh) ≥ 1.0, [uv](https://docs.astral.sh/uv/getting-started/installation/)
 
 ```bash
 # 1. Clone and install backend in editable mode
 git clone https://github.com/Good0007/nanobot-webui.git
 cd nanobot-webui
-pip install -e .
+uv venv               # create a virtual env - don't mess with central python install
+uv pip install -e .
 
 # 2. Start the backend
-nanobot webui                        # API + static on :8080
+uv run webui                        # API + static on :8080
 
 # 3. Start the frontend dev server (separate terminal)
 cd web
@@ -251,7 +252,7 @@ To produce a production build:
 cd web
 bun run build          # outputs to web/dist/, setup.py copies it to webui/web/dist/
 cd ..
-nanobot webui          # backend now serves webui/web/dist/ as static files
+uv run nanobot webui          # backend now serves webui/web/dist/ as static files
 ```
 
 ---

--- a/README_zh.md
+++ b/README_zh.md
@@ -232,10 +232,11 @@ Model: gpt-4o
 # 1. 克隆仓库并以可编辑模式安装后端
 git clone https://github.com/Good0007/nanobot-webui.git
 cd nanobot-webui
-pip install -e .
+uv venv               # 创建虚拟环境——不要修改中央 Python 安装。
+uv pip install -e .
 
 # 2. 启动后端
-nanobot webui                        # API + 静态文件服务于 :8080
+uv run webui                        # API + 静态文件服务于 :8080
 
 # 3. 启动前端开发服务器（另开终端）
 cd web


### PR DESCRIPTION
Right now, the developer instructions can mess with the central python installation.  This PR shows an alternative venv based dev setup for developers.

PS: I found your work from https://github.com/HKUDS/nanobot/issues/1922