### PR TITLE
feat: support multi-session concurrent chat and message revoke

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -29,6 +29,7 @@
         "axios": "^1.7.0",
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.0",
+        "diff": "^8.0.3",
         "i18next": "^23.15.0",
         "i18next-browser-languagedetector": "^8.0.0",
         "lucide-react": "^0.462.0",
@@ -3707,9 +3708,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3724,9 +3722,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3741,9 +3736,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3758,9 +3750,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3775,9 +3764,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3792,9 +3778,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3809,9 +3792,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3826,9 +3806,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3843,9 +3820,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3860,9 +3834,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3877,9 +3848,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3894,9 +3862,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3911,9 +3876,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5174,6 +5136,15 @@
       "version": "1.2.2",
       "dev": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/diff": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.3.tgz",
+      "integrity": "sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
     },
     "node_modules/dlv": {
       "version": "1.1.3",

--- a/web/src/components/chat/ChatWindow.tsx
+++ b/web/src/components/chat/ChatWindow.tsx
@@ -6,6 +6,7 @@ import { useChatStore } from "../../stores/chatStore";
 import { ChatWebSocket, type WsMessage } from "../../lib/ws";
 import { MessageBubble } from "./MessageBubble";
 import { ChatInput } from "./ChatInput";
+import { useRevokeMessage } from "../../hooks/useSessions";
 
 export function ChatWindow() {
   const { t } = useTranslation();
@@ -13,8 +14,6 @@ export function ChatWindow() {
   const {
     currentSessionKey,
     messages,
-    isWaiting,
-    progressText,
     showToolMessages,
     addMessage,
     setWaiting,
@@ -22,6 +21,14 @@ export function ChatWindow() {
     setCurrentSession,
     toggleToolMessages,
   } = useChatStore();
+
+  // Read per-session state for the active session
+  const sessionState = useChatStore((s) => {
+    const key = s.currentSessionKey ?? "";
+    return s.sessionStates[key] ?? { isWaiting: false, progressText: "" };
+  });
+  const isWaiting = sessionState.isWaiting;
+  const progressText = sessionState.progressText;
 
   const visibleMessages = showToolMessages
     ? messages
@@ -33,6 +40,7 @@ export function ChatWindow() {
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const handleWsMessageRef = useRef<(msg: WsMessage) => void>(() => {});
   const [isConnected, setIsConnected] = useState(false);
+  const revokeMessage = useRevokeMessage();
 
   useEffect(() => {
     const ws = new ChatWebSocket(
@@ -61,55 +69,77 @@ export function ChatWindow() {
 
   const handleWsMessage = useCallback(
     (msg: WsMessage) => {
+      // Determine which session this message belongs to
+      const msgSessionKey = msg.session_key;
+      const currentKey = useChatStore.getState().currentSessionKey;
+
       if (msg.type === "session_info") {
-        if (msg.session_key && msg.session_key !== useChatStore.getState().currentSessionKey) {
+        if (msg.session_key && msg.session_key !== currentKey) {
           setCurrentSession(msg.session_key);
         }
       } else if (msg.type === "progress") {
-        setProgress(msg.content ?? "");
+        // Update per-session progress
+        const targetKey = msgSessionKey || currentKey || "";
+        setProgress(msg.content ?? "", targetKey);
       } else if (msg.type === "subagent_progress") {
-        // SubAgent tool-call hint — arrives after main agent's "done", so render
-        // as a persistent SubAgent bubble rather than the transient progress indicator.
-        if (msg.content?.trim()) {
-          addMessage({
-            id: nanoid(),
-            role: "tool",
-            content: msg.content,
-            timestamp: new Date().toISOString(),
-            isSubAgent: true,
-          });
+        // Only show in UI if this is for the currently viewed session
+        if (!msgSessionKey || msgSessionKey === currentKey) {
+          if (msg.content?.trim()) {
+            addMessage({
+              id: nanoid(),
+              role: "tool",
+              content: msg.content,
+              timestamp: new Date().toISOString(),
+              isSubAgent: true,
+            });
+          }
         }
       } else if (msg.type === "done") {
-        setProgress("");
-        setWaiting(false);
+        const targetKey = msgSessionKey || currentKey || "";
+        setProgress("", targetKey);
+        setWaiting(false, targetKey);
+
         if (assistantMsgIdRef.current) {
           useChatStore.getState().setStreaming(assistantMsgIdRef.current, false);
           assistantMsgIdRef.current = null;
         }
-        if (msg.content?.trim()) {
+
+        // Only add message to UI if it's for the currently viewed session
+        if (!msgSessionKey || msgSessionKey === currentKey) {
+          if (msg.content?.trim()) {
+            addMessage({
+              id: nanoid(),
+              role: "assistant",
+              content: msg.content,
+              timestamp: new Date().toISOString(),
+            });
+          }
+        }
+
+        // Refresh sessions list and the session's messages
+        qc.invalidateQueries({ queryKey: ["sessions"] });
+        if (targetKey) {
+          qc.invalidateQueries({ queryKey: ["sessions", targetKey, "messages"] });
+        }
+      } else if (msg.type === "error") {
+        const targetKey = msgSessionKey || currentKey || "";
+        setProgress("", targetKey);
+        setWaiting(false, targetKey);
+
+        // Only show error in UI if it's for the currently viewed session
+        if (!msgSessionKey || msgSessionKey === currentKey) {
           addMessage({
             id: nanoid(),
             role: "assistant",
-            content: msg.content,
+            content: `⚠️ ${msg.content ?? t("common.error")}`,
             timestamp: new Date().toISOString(),
           });
         }
-        // Refresh sessions list and current session's messages (so tool call/result
-        // messages that were saved server-side appear without requiring a page reload).
+      } else if (msg.type === "revoke_ok") {
+        // Refresh the session messages after revoke
+        const targetKey = msgSessionKey || currentKey || "";
+        qc.invalidateQueries({ queryKey: ["sessions", targetKey, "messages"] });
         qc.invalidateQueries({ queryKey: ["sessions"] });
-        const sessKey = useChatStore.getState().currentSessionKey;
-        if (sessKey) {
-          qc.invalidateQueries({ queryKey: ["sessions", sessKey, "messages"] });
-        }
-      } else if (msg.type === "error") {
-        setProgress("");
-        setWaiting(false);
-        addMessage({
-          id: nanoid(),
-          role: "assistant",
-          content: `⚠️ ${msg.content ?? t("common.error")}`,
-          timestamp: new Date().toISOString(),
-        });
       }
     },
     [addMessage, qc, setCurrentSession, setProgress, setWaiting, t]
@@ -130,18 +160,75 @@ export function ChatWindow() {
         content,
         timestamp: new Date().toISOString(),
       });
-      setWaiting(true);
-      setProgress(t("chat.thinking"));
+      const key = currentSessionKey ?? "";
+      setWaiting(true, key);
+      setProgress(t("chat.thinking"), key);
       wsRef.current?.send(content, currentSessionKey ?? undefined);
     },
     [addMessage, currentSessionKey, setProgress, setWaiting, t]
   );
 
   const handleStop = useCallback(() => {
-    wsRef.current?.cancel();
-    setWaiting(false);
-    setProgress("");
-  }, [setProgress, setWaiting]);
+    const key = currentSessionKey ?? "";
+    wsRef.current?.cancel(key);
+    setWaiting(false, key);
+    setProgress("", key);
+  }, [currentSessionKey, setProgress, setWaiting]);
+
+  const handleRevoke = useCallback(
+    (messageId: string) => {
+      if (!currentSessionKey) return;
+      // Find the message index in the *server* data by matching content + role.
+      // The `messageId` is the local nanoid, find the corresponding server index.
+      const msg = messages.find((m) => m.id === messageId);
+      if (!msg) return;
+
+      // Find index among all messages (including filtered ones)
+      const allMsgs = useChatStore.getState().messages;
+      // Count visible messages of the same role+content to find server-side index
+      // We need to find the index in the original session messages list
+      let serverIndex = -1;
+      let matchCount = 0;
+      for (let i = 0; i < allMsgs.length; i++) {
+        if (allMsgs[i].id === messageId) {
+          serverIndex = matchCount;
+          break;
+        }
+        // Only count messages that would exist on the server (skip locally-added errors)
+        if (allMsgs[i].role !== "assistant" || !allMsgs[i].content.startsWith("⚠️")) {
+          matchCount++;
+        }
+      }
+
+      if (serverIndex >= 0) {
+        revokeMessage.mutate(
+          { key: currentSessionKey, index: serverIndex },
+          {
+            onSuccess: () => {
+              // Remove from local store immediately
+              const state = useChatStore.getState();
+              const idx = state.messages.findIndex((m) => m.id === messageId);
+              if (idx >= 0) {
+                const newMsgs = [...state.messages];
+                if (msg.role === "user") {
+                  // Also remove subsequent non-user messages
+                  let end = idx + 1;
+                  while (end < newMsgs.length && newMsgs[end].role !== "user") {
+                    end++;
+                  }
+                  newMsgs.splice(idx, end - idx);
+                } else {
+                  newMsgs.splice(idx, 1);
+                }
+                useChatStore.getState().setMessages(newMsgs);
+              }
+            },
+          }
+        );
+      }
+    },
+    [currentSessionKey, messages, revokeMessage]
+  );
 
   return (
     <div className="flex flex-1 min-h-0 flex-col">
@@ -159,7 +246,11 @@ export function ChatWindow() {
         ) : (
           <div className="space-y-4">
             {visibleMessages.map((msg) => (
-              <MessageBubble key={msg.id} message={msg} />
+              <MessageBubble
+                key={msg.id}
+                message={msg}
+                onRevoke={handleRevoke}
+              />
             ))}
           </div>
         )}

--- a/web/src/components/chat/MessageBubble.tsx
+++ b/web/src/components/chat/MessageBubble.tsx
@@ -7,10 +7,11 @@ import type { ChatMessage } from "../../stores/chatStore";
 import { ToolCallCard } from "./ToolCallCard";
 import { ThinkingBlock } from "./ThinkingBlock";
 import { useAuthStore } from "../../stores/authStore";
-import { Info, ChevronDown, ChevronRight, CheckCircle2, XCircle, Bot, Wrench, Copy, Check } from "lucide-react";
+import { Info, ChevronDown, ChevronRight, CheckCircle2, XCircle, Bot, Wrench, Copy, Check, Undo2 } from "lucide-react";
 
 interface MessageBubbleProps {
   message: ChatMessage;
+  onRevoke?: (messageId: string) => void;
 }
 
 function splitThinking(content: string): { type: "text" | "thinking"; content: string }[] {
@@ -228,7 +229,7 @@ function ToolMessageWrapper({ children }: { children: React.ReactNode }) {
   );
 }
 
-export function MessageBubble({ message }: MessageBubbleProps) {
+export function MessageBubble({ message, onRevoke }: MessageBubbleProps) {
   const user = useAuthStore((s) => s.user);
 
   // Don't render anything for empty/whitespace messages
@@ -338,6 +339,16 @@ export function MessageBubble({ message }: MessageBubbleProps) {
               {copied
                 ? <Check className="h-3 w-3 text-emerald-500" />
                 : <Copy className="h-3 w-3" />}
+            </button>
+          )}
+          {!message.isStreaming && onRevoke && (
+            <button
+              onClick={() => onRevoke(message.id)}
+              className="opacity-0 group-hover:opacity-100 transition-opacity text-muted-foreground/50 hover:text-red-500 p-0.5 rounded"
+              aria-label="Revoke message"
+              title={isUser ? "Revoke message & response" : "Revoke message"}
+            >
+              <Undo2 className="h-3 w-3" />
             </button>
           )}
         </div>

--- a/web/src/hooks/useSessions.ts
+++ b/web/src/hooks/useSessions.ts
@@ -55,3 +55,16 @@ export function useDeleteSession() {
     },
   });
 }
+
+export function useRevokeMessage() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ key, index }: { key: string; index: number }) =>
+      api.delete(`/sessions/${encodeURIComponent(key)}/messages/${index}`).then((r) => r.data),
+    onSuccess: (_data, vars) => {
+      qc.invalidateQueries({ queryKey: ["sessions", vars.key, "messages"] });
+      qc.invalidateQueries({ queryKey: ["sessions"] });
+      toast.success(i18n.t("chat.messageRevoked", "Message revoked"));
+    },
+  });
+}

--- a/web/src/lib/ws.ts
+++ b/web/src/lib/ws.ts
@@ -1,12 +1,13 @@
 import { useAuthStore } from "../stores/authStore";
 
-export type WsMessageType = "session_info" | "progress" | "subagent_progress" | "done" | "error";
+export type WsMessageType = "session_info" | "progress" | "subagent_progress" | "done" | "error" | "revoke_ok";
 
 export interface WsMessage {
   type: WsMessageType;
   content?: string;
   session_key?: string;
   tool_hint?: boolean;
+  index?: number;
 }
 
 type MessageHandler = (msg: WsMessage) => void;
@@ -80,9 +81,16 @@ export class ChatWebSocket {
     this.sessionKey = sessionKey;
   }
 
-  cancel() {
+  cancel(sessionKey?: string) {
     if (this.ws?.readyState === WebSocket.OPEN) {
-      this.ws.send(JSON.stringify({ type: "cancel" }));
+      this.ws.send(JSON.stringify({ type: "cancel", session_key: sessionKey }));
+    }
+  }
+
+  /** Revoke (delete) a message by index in a session. */
+  revoke(sessionKey: string, index: number) {
+    if (this.ws?.readyState === WebSocket.OPEN) {
+      this.ws.send(JSON.stringify({ type: "revoke", session_key: sessionKey, index }));
     }
   }
 

--- a/web/src/pages/Chat.tsx
+++ b/web/src/pages/Chat.tsx
@@ -27,6 +27,7 @@ export default function Chat() {
   const mobileShowChat = useChatStore((s) => s.mobileShowChat);
   const setMobileShowChat = useChatStore((s) => s.setMobileShowChat);
   const { currentSessionKey, setCurrentSession, setMessages } = useChatStore();
+  const sessionStates = useChatStore((s) => s.sessionStates);
   const { data: sessions } = useSessions();
   const { data: sessionMsgs, isSuccess: historyLoaded } = useSessionMessages(currentSessionKey ?? "");
   const deleteSession = useDeleteSession();
@@ -217,6 +218,7 @@ export default function Chat() {
               const maxLen = isMobile ? 28 : 14;
               const label = rawLabel.length > maxLen ? rawLabel.slice(0, maxLen) + "…" : rawLabel;
               const active = s.key === currentSessionKey;
+              const sessionBusy = sessionStates[s.key]?.isWaiting ?? false;
               return (
                 <div
                   key={s.key}
@@ -259,7 +261,16 @@ export default function Chat() {
                       isMobile ? "text-xs" : "text-[10px]",
                       active ? "text-orange-700 dark:text-orange-200" : "text-muted-foreground"
                     )}>
-                      {s.last_message || "—"}
+                      {sessionBusy ? (
+                        <span className="inline-flex items-center gap-1">
+                          <span className="flex gap-0.5">
+                            <span className="h-1 w-1 rounded-full bg-primary animate-bounce [animation-delay:0ms]" />
+                            <span className="h-1 w-1 rounded-full bg-primary animate-bounce [animation-delay:150ms]" />
+                            <span className="h-1 w-1 rounded-full bg-primary animate-bounce [animation-delay:300ms]" />
+                          </span>
+                          <span className="text-primary/70">Processing…</span>
+                        </span>
+                      ) : (s.last_message || "—")}
                     </p>
                   </div>
 

--- a/web/src/stores/chatStore.ts
+++ b/web/src/stores/chatStore.ts
@@ -19,34 +19,61 @@ export interface ToolCallInfo {
   output?: string;
 }
 
+/** Per-session transient state (waiting indicator, progress text). */
+interface SessionState {
+  isWaiting: boolean;
+  progressText: string;
+}
+
 interface ChatState {
   currentSessionKey: string | null;
   messages: ChatMessage[];
-  isWaiting: boolean;
-  progressText: string;
   showToolMessages: boolean;
   mobileShowChat: boolean;
+
+  /** Per-session waiting / progress state — keyed by session key. */
+  sessionStates: Record<string, SessionState>;
+
+  // Convenience getters for the *current* session
+  isWaiting: boolean;
+  progressText: string;
+
   setMobileShowChat: (v: boolean) => void;
   setCurrentSession: (key: string | null) => void;
   addMessage: (msg: ChatMessage) => void;
   appendAssistantText: (id: string, text: string) => void;
   setStreaming: (id: string, isStreaming: boolean) => void;
-  setProgress: (text: string) => void;
-  setWaiting: (v: boolean) => void;
+  /** Set progress for a specific session (defaults to current). */
+  setProgress: (text: string, sessionKey?: string) => void;
+  /** Set waiting for a specific session (defaults to current). */
+  setWaiting: (v: boolean, sessionKey?: string) => void;
   clearMessages: () => void;
   setMessages: (msgs: ChatMessage[]) => void;
   toggleToolMessages: () => void;
+  /** Get waiting state for a specific session. */
+  getSessionState: (key: string) => SessionState;
 }
+
+const DEFAULT_SESSION_STATE: SessionState = { isWaiting: false, progressText: "" };
 
 export const useChatStore = create<ChatState>()(
   persist(
-    (set) => ({
+    (set, get) => ({
       currentSessionKey: null,
       messages: [],
-      isWaiting: false,
-      progressText: "",
       showToolMessages: false,
       mobileShowChat: false,
+      sessionStates: {},
+
+      // Derived from sessionStates[currentSessionKey]
+      get isWaiting() {
+        const s = get();
+        return (s.sessionStates[s.currentSessionKey ?? ""] ?? DEFAULT_SESSION_STATE).isWaiting;
+      },
+      get progressText() {
+        const s = get();
+        return (s.sessionStates[s.currentSessionKey ?? ""] ?? DEFAULT_SESSION_STATE).progressText;
+      },
 
       setMobileShowChat: (v) => set({ mobileShowChat: v }),
 
@@ -54,7 +81,6 @@ export const useChatStore = create<ChatState>()(
         set((state) => ({
           currentSessionKey: key,
           messages: state.currentSessionKey === key ? state.messages : [],
-          progressText: state.currentSessionKey === key ? state.progressText : "",
         })),
 
       addMessage: (msg) =>
@@ -74,16 +100,37 @@ export const useChatStore = create<ChatState>()(
           ),
         })),
 
-      setProgress: (progressText) => set({ progressText }),
+      setProgress: (progressText, sessionKey?) =>
+        set((state) => {
+          const key = sessionKey ?? state.currentSessionKey ?? "";
+          const prev = state.sessionStates[key] ?? DEFAULT_SESSION_STATE;
+          return {
+            sessionStates: { ...state.sessionStates, [key]: { ...prev, progressText } },
+          };
+        }),
 
-      setWaiting: (isWaiting) => set({ isWaiting }),
+      setWaiting: (isWaiting, sessionKey?) =>
+        set((state) => {
+          const key = sessionKey ?? state.currentSessionKey ?? "";
+          const prev = state.sessionStates[key] ?? DEFAULT_SESSION_STATE;
+          return {
+            sessionStates: {
+              ...state.sessionStates,
+              [key]: { ...prev, isWaiting, ...(isWaiting ? {} : { progressText: "" }) },
+            },
+          };
+        }),
 
-      clearMessages: () => set({ messages: [], progressText: "" }),
+      clearMessages: () => set({ messages: [] }),
 
       setMessages: (messages) => set({ messages }),
 
       toggleToolMessages: () =>
         set((state) => ({ showToolMessages: !state.showToolMessages })),
+
+      getSessionState: (key) => {
+        return get().sessionStates[key] ?? DEFAULT_SESSION_STATE;
+      },
     }),
     {
       name: "nanobot-chat",

--- a/webui/api/routes/sessions.py
+++ b/webui/api/routes/sessions.py
@@ -86,6 +86,43 @@ async def get_session_memory(
     }
 
 
+@router.delete("/{key:path}/messages/{index}", status_code=200)
+async def revoke_message(
+    key: str,
+    index: int,
+    current_user: Annotated[dict, Depends(get_current_user)],
+    svc: Annotated[ServiceContainer, Depends(get_services)],
+) -> dict:
+    """Revoke (delete) a message by index.
+
+    If the target is a user message, also remove the subsequent assistant/tool
+    response messages that form the reply pair.
+    """
+    if not _is_own_session(key, current_user):
+        raise HTTPException(status.HTTP_403_FORBIDDEN, "Access denied")
+
+    session = svc.session_manager.get_or_create(key)
+    if index < 0 or index >= len(session.messages):
+        raise HTTPException(status.HTTP_400_BAD_REQUEST, "Invalid message index")
+
+    removed = session.messages[index]
+    if removed.get("role") == "user":
+        # Remove user message and all subsequent non-user messages (the response pair)
+        end = index + 1
+        while end < len(session.messages) and session.messages[end].get("role") != "user":
+            end += 1
+        count = end - index
+        del session.messages[index:end]
+    else:
+        count = 1
+        del session.messages[index]
+
+    from datetime import datetime
+    session.updated_at = datetime.now()
+    svc.session_manager.save(session)
+    return {"removed": count}
+
+
 @router.delete("/{key:path}", status_code=204)
 async def delete_session(
     key: str,

--- a/webui/api/routes/ws.py
+++ b/webui/api/routes/ws.py
@@ -140,7 +140,9 @@ async def ws_chat(websocket: WebSocket) -> None:
 
     await websocket.send_json({"type": "session_info", "session_key": session_key})
 
-    current_task: asyncio.Task | None = None
+    # Per-session task tracking: allows multiple sessions to run concurrently
+    # through a single WebSocket connection.
+    session_tasks: dict[str, asyncio.Task] = {}
 
     try:
         while True:
@@ -148,13 +150,61 @@ async def ws_chat(websocket: WebSocket) -> None:
             msg_type = raw.get("type")
 
             if msg_type == "cancel":
-                if current_task and not current_task.done():
-                    current_task.cancel()
-                    await websocket.send_json({"type": "error", "content": "cancelled"})
+                # Cancel the task for a specific session, or the current session
+                cancel_key = raw.get("session_key") or session_key
+                task = session_tasks.get(cancel_key)
+                if task and not task.done():
+                    task.cancel()
+                    await websocket.send_json({
+                        "type": "error",
+                        "content": "cancelled",
+                        "session_key": cancel_key,
+                    })
 
             elif msg_type == "new_session":
                 session_key = f"web:{user['id']}:{uuid.uuid4().hex[:8]}"
                 await websocket.send_json({"type": "session_info", "session_key": session_key})
+
+            elif msg_type == "revoke":
+                # Revoke (delete) a specific message by index from session history
+                revoke_key = raw.get("session_key") or session_key
+                msg_index = raw.get("index")
+                if msg_index is not None and _is_allowed_session(revoke_key):
+                    try:
+                        session = container.agent.sessions.get_or_create(revoke_key)
+                        idx = int(msg_index)
+                        if 0 <= idx < len(session.messages):
+                            removed = session.messages[idx]
+                            # If revoking a user message, also remove the subsequent
+                            # assistant/tool messages that form the response pair
+                            if removed.get("role") == "user":
+                                # Find extent: remove everything until the next user msg
+                                end = idx + 1
+                                while end < len(session.messages) and session.messages[end].get("role") != "user":
+                                    end += 1
+                                del session.messages[idx:end]
+                            else:
+                                del session.messages[idx]
+                            from datetime import datetime
+                            session.updated_at = datetime.now()
+                            container.agent.sessions.save(session)
+                            await websocket.send_json({
+                                "type": "revoke_ok",
+                                "session_key": revoke_key,
+                                "index": msg_index,
+                            })
+                        else:
+                            await websocket.send_json({
+                                "type": "error",
+                                "content": "Invalid message index",
+                                "session_key": revoke_key,
+                            })
+                    except Exception as exc:
+                        await websocket.send_json({
+                            "type": "error",
+                            "content": f"Revoke failed: {exc}",
+                            "session_key": revoke_key,
+                        })
 
             elif msg_type == "message":
                 content = raw.get("content", "")
@@ -168,19 +218,25 @@ async def ws_chat(websocket: WebSocket) -> None:
                 if not content:
                     continue
 
-                if current_task and not current_task.done():
+                effective_key = msg_session_key or session_key
+
+                # Check if this specific session already has an active task
+                existing_task = session_tasks.get(effective_key)
+                if existing_task and not existing_task.done():
                     await websocket.send_json({
                         "type": "error",
-                        "content": "Previous message still processing",
+                        "content": "Previous message still processing in this session",
+                        "session_key": effective_key,
                     })
                     continue
 
-                async def _on_progress(text: str, *, tool_hint: bool = False) -> None:
+                async def _on_progress(text: str, *, tool_hint: bool = False, _sk: str = effective_key) -> None:
                     try:
                         await websocket.send_json({
                             "type": "progress",
                             "content": text,
                             "tool_hint": tool_hint,
+                            "session_key": _sk,
                         })
                     except Exception:
                         pass
@@ -205,37 +261,23 @@ async def ws_chat(websocket: WebSocket) -> None:
                                 "type": "subagent_progress",
                                 "content": text,
                                 "tool_hint": True,
+                                "session_key": sess,
                             })
                         except Exception:
                             pass
 
                     async def _on_subagent_save_turn(all_messages: list) -> None:
-                        """Persist SubAgent's full tool-call chain to the main session.
-
-                        all_messages structure (from SubAgent):
-                          [0] system prompt  (skip)
-                          [1] user: task     (skip)
-                          [2+] assistant(tool_calls) / tool / assistant(final)
-
-                        Tool-call messages are saved with role="sub_tool" so the UI
-                        can render them differently.  session.py patches get_history()
-                        to remap sub_tool → assistant/tool before sending to any LLM.
-
-                        A system bridge message is prepended to separate the main
-                        agent's last assistant turn from SubAgent content.
-                        """
+                        """Persist SubAgent's full tool-call chain to the main session."""
                         try:
                             from datetime import datetime
-                            _TRUNCATE = 500  # matches AgentLoop._TOOL_RESULT_MAX_CHARS
+                            _TRUNCATE = 500
                             session = container.agent.sessions.get_or_create(sess)
-                            # Separator: not shown as a user bubble in the UI
                             session.add_message("system", "[Background task progress]")
                             now = datetime.now().isoformat()
-                            for m in all_messages[2:]:  # skip SubAgent system+user
+                            for m in all_messages[2:]:
                                 role = m.get("role", "")
                                 content = m.get("content") or ""
                                 if role == "assistant" and m.get("tool_calls"):
-                                    # Tool-call declaration → sub_tool
                                     session.messages.append({
                                         "role": "sub_tool",
                                         "content": content,
@@ -243,7 +285,6 @@ async def ws_chat(websocket: WebSocket) -> None:
                                         "timestamp": now,
                                     })
                                 elif role == "tool":
-                                    # Tool result → sub_tool (truncate if large)
                                     if isinstance(content, str) and len(content) > _TRUNCATE:
                                         content = content[:_TRUNCATE] + "\n... (truncated)"
                                     session.messages.append({
@@ -254,7 +295,6 @@ async def ws_chat(websocket: WebSocket) -> None:
                                         "timestamp": now,
                                     })
                                 elif role == "assistant":
-                                    # Final result (no tool_calls) — keep as assistant
                                     if not content:
                                         continue
                                     session.messages.append({
@@ -268,9 +308,12 @@ async def ws_chat(websocket: WebSocket) -> None:
                             pass
 
                     async def _on_subagent_done(text: str) -> None:
-                        # Session already saved by _on_subagent_save_turn before this fires.
                         try:
-                            await websocket.send_json({"type": "done", "content": text})
+                            await websocket.send_json({
+                                "type": "done",
+                                "content": text,
+                                "session_key": sess,
+                            })
                         except Exception:
                             pass
 
@@ -285,8 +328,6 @@ async def ws_chat(websocket: WebSocket) -> None:
                             chat_id=user["id"],
                             on_progress=_on_progress,
                         )
-                        # If the agent replied via message() tool, process_direct
-                        # returns "".  Drain whatever the patched callback captured.
                         if not response:
                             collected: list[str] = []
                             while not capture_q.empty():
@@ -295,13 +336,21 @@ async def ws_chat(websocket: WebSocket) -> None:
                                 except asyncio.QueueEmpty:
                                     break
                             response = "\n\n".join(c for c in collected if c)
-                        await websocket.send_json({"type": "done", "content": response})
+                        await websocket.send_json({
+                            "type": "done",
+                            "content": response,
+                            "session_key": sess,
+                        })
                     except asyncio.CancelledError:
                         pass
                     except Exception as exc:
                         logger.error("WebSocket agent error: {}", exc)
                         try:
-                            await websocket.send_json({"type": "error", "content": str(exc)})
+                            await websocket.send_json({
+                                "type": "error",
+                                "content": str(exc),
+                                "session_key": sess,
+                            })
                         except Exception:
                             pass
                     finally:
@@ -310,16 +359,16 @@ async def ws_chat(websocket: WebSocket) -> None:
                             lst.remove(capture_q)
                         if not lst:
                             _web_captures.pop(uid, None)
-                        # Unregister only when WebSocket closes or errors, not here,
-                        # because SubAgent may still be running in the background.
-                        # The registry entry is overwritten on the next message and
-                        # errors inside _emit_progress are silently swallowed.
+                        # Clean up finished task from tracking dict
+                        session_tasks.pop(sess, None)
 
-                current_task = asyncio.create_task(_run_agent(content, session_key))
+                task = asyncio.create_task(_run_agent(content, effective_key))
+                session_tasks[effective_key] = task
 
     except WebSocketDisconnect:
-        if current_task and not current_task.done():
-            current_task.cancel()
+        for task in session_tasks.values():
+            if not task.done():
+                task.cancel()
     except Exception as exc:
         logger.error("WebSocket error: {}", exc)
         try:


### PR DESCRIPTION
## Summary

Support multi-session concurrent chat through a single WebSocket connection, and add message revoke feature.

## Changes

### Frontend
- **chatStore**: per-session state (`sessionStates` map) replacing global singleton
- **ws.ts**: single WS multiplexes sessions with `session_key` routing; add `revoke()` and `cancel(sessionKey)`
- **ChatWindow**: route WS messages by `session_key`; add revoke callback
- **MessageBubble**: hover revoke button (Undo2 icon)
- **Chat sidebar**: per-session busy indicator (bouncing dots)
- **useSessions**: add `useRevokeMessage()` mutation

### Backend
- **sessions.py**: `DELETE /{key}/messages/{index}` with user-message cascade
- **ws.py**: `session_tasks` dict for concurrent per-session agents; `revoke` and targeted `cancel` WS commands
