### PR TITLE
fix: resolve duplicate messages and revoke index issues from PR#8

### DIFF
--- a/web/src/components/chat/ChatWindow.tsx
+++ b/web/src/components/chat/ChatWindow.tsx
@@ -79,6 +79,24 @@ export function ChatWindow() {
         }
       } else if (msg.type === "progress") {
         // Update per-session progress
+          if (msg.content?.trim()) {
+            if (msg.tool_hint) {
+              addMessage({
+                id: nanoid(),
+                role: "tool",
+                content: msg.content,
+                timestamp: new Date().toISOString(),
+              });
+            } else {
+              //追加到 assistant 消息区
+              addMessage({
+                id: nanoid(),
+                role: "assistant",
+                content: msg.content,
+                timestamp: new Date().toISOString(),
+              });
+            }
+        }
         const targetKey = msgSessionKey || currentKey || "";
         setProgress(msg.content ?? "", targetKey);
       } else if (msg.type === "subagent_progress") {
@@ -178,27 +196,13 @@ export function ChatWindow() {
   const handleRevoke = useCallback(
     (messageId: string) => {
       if (!currentSessionKey) return;
-      // Find the message index in the *server* data by matching content + role.
-      // The `messageId` is the local nanoid, find the corresponding server index.
       const msg = messages.find((m) => m.id === messageId);
       if (!msg) return;
 
-      // Find index among all messages (including filtered ones)
-      const allMsgs = useChatStore.getState().messages;
-      // Count visible messages of the same role+content to find server-side index
-      // We need to find the index in the original session messages list
-      let serverIndex = -1;
-      let matchCount = 0;
-      for (let i = 0; i < allMsgs.length; i++) {
-        if (allMsgs[i].id === messageId) {
-          serverIndex = matchCount;
-          break;
-        }
-        // Only count messages that would exist on the server (skip locally-added errors)
-        if (allMsgs[i].role !== "assistant" || !allMsgs[i].content.startsWith("⚠️")) {
-          matchCount++;
-        }
-      }
+      // serverIndex is stored when messages are loaded from the server in Chat.tsx.
+      // Locally-added messages (e.g. error bubbles) have no serverIndex and cannot be revoked.
+      const serverIndex = msg.serverIndex;
+      if (serverIndex === undefined) return;
 
       if (serverIndex >= 0) {
         revokeMessage.mutate(

--- a/web/src/pages/Chat.tsx
+++ b/web/src/pages/Chat.tsx
@@ -55,6 +55,7 @@ export default function Chat() {
     // Filter out empty messages only (assistant stubs with null/empty content).
     // tool and system messages are included but rendered differently.
     const msgs = (sessionMsgs ?? [])
+      .map((m, idx) => ({ ...m, _serverIdx: idx })) // preserve original server index before filtering
       .filter((m) =>
         typeof m.content === "string" &&
         m.content.trim().length > 0 &&
@@ -69,6 +70,7 @@ export default function Chat() {
         content: m.content as string,
         timestamp: m.timestamp ?? new Date().toISOString(),
         name: m.name ?? undefined,
+        serverIndex: m._serverIdx,
       }));
     // Only overwrite if we got actual history (avoids wiping persisted messages on new empty sessions)
     if (msgs.length > 0) {
@@ -81,9 +83,13 @@ export default function Chat() {
       // time (no Z) while JS new Date().toISOString() uses UTC (with Z), making string
       // comparison unreliable across timezones.
       const prevIds = new Set(lastSetMsgsRef.current.map((m) => m.id));
-      const serverContents = new Set(msgs.map((m) => m.content));
+      // Only preserve locally-added error messages — they are never saved server-side.
+      // All other messages (including done responses) will be re-loaded from server data.
       const localToPreserve = useChatStore.getState().messages.filter(
-        (m) => !prevIds.has(m.id) && m.role !== "user" && !serverContents.has(m.content)
+        (m) =>
+          !prevIds.has(m.id) &&
+          m.role === "assistant" &&
+          m.content.startsWith("⚠️")
       );
       const merged = localToPreserve.length > 0 ? [...msgs, ...localToPreserve] : msgs;
       lastSetMsgsRef.current = merged;

--- a/web/src/stores/chatStore.ts
+++ b/web/src/stores/chatStore.ts
@@ -10,6 +10,7 @@ export interface ChatMessage {
   toolCalls?: ToolCallInfo[];
   name?: string; // tool result: the tool's name
   isSubAgent?: boolean; // message originated from a background SubAgent
+  serverIndex?: number; // original index in the server session.messages array (used for revoke)
 }
 
 export interface ToolCallInfo {


### PR DESCRIPTION
- Chat.tsx: localToPreserve now only preserves local error messages (⚠️) instead of content-based dedup which failed on trailing \n mismatches
- Chat.tsx: record original server index (_serverIdx) before filtering messages, and store it as serverIndex on each ChatMessage
- chatStore.ts: add serverIndex field to ChatMessage interface
- ChatWindow.tsx: handleRevoke uses msg.serverIndex directly instead of unreliable counting logic that could mis-identify messages after tool/sub_tool filtering