### PR TITLE
fix: support dynamic arguments in Session.get_history monkey patch

### DIFF
--- a/webui/patches/session.py
+++ b/webui/patches/session.py
@@ -76,8 +76,8 @@ def apply() -> None:
     # is also assistant — the system line separates them).
     _orig_get_history = _session_manager.Session.get_history
 
-    def _get_history_patched(self, max_messages: int = 500):  # type: ignore[override]
-        history = _orig_get_history(self, max_messages)
+    def _get_history_patched(self, *args, **kwargs):  # type: ignore[override]
+        history = _orig_get_history(self, *args, **kwargs)
         return [m for m in history if m.get("role") != "sub_tool"]
 
     _session_manager.Session.get_history = _get_history_patched  # type: ignore[method-assign]


### PR DESCRIPTION
Problem
The nanobot core recently updated the Session.get_history() signature to support token-based history management via the max_tokens keyword argument.

The current monkey patch in webui/patches/session.py defines _get_history_patched with a rigid signature that only accepts max_messages. When the nanobot agent loop calls this method passing max_tokens (common in recent versions), it triggers a fatal TypeError: TypeError: _get_history_patched() got an unexpected keyword argument 'max_tokens'

This effectively crashes the agent whenever it attempts to process a message while the WebUI patches are active.

Solution
This PR updates the _get_history_patched signature to use *args and **kwargs. This makes the patch forward-compatible with any future signature changes in the core nanobot library while still maintaining the intended behavior of filtering out sub_tool roles from the LLM context.

Changes
Updated _get_history_patched in webui/patches/session.py to accept and forward all arguments (*args, **kwargs) to the original get_history method.